### PR TITLE
fix: proper time played handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ let stats_operator = new Stats.dataOperator();
 
 const API_ERROR = `If you see this error, it means it's an API error, please report this error on Github.`;
 
+const time_played_regex = /\d*h/
+
 module.exports = {
     general: async function (platform, name) {
         if (typeof platform !== 'string' || typeof name !== 'string') return 'FORMAT_ERROR';
@@ -50,7 +52,8 @@ module.exports = {
         stats_general.headshot_ = profile[profile.indexOf('Headshot %') + 1];
         stats_general.headshots = checkNumber(profile[profile.indexOf('Headshots') + 1]);
 
-        stats_general.time_played = profile[profile.indexOf('Time Played') + 1];
+        time_played = profile[profile.indexOf('Time Played') + 1];
+        stats_general.time_played = time_played.match(time_played_regex)? time_played: null;
         stats_general.matches_played = checkNumber(profile[profile.indexOf('Matches Played') + 1]);
         stats_general.total_xp = profile[profile.indexOf('Total XP') + 1];
         stats_general.melee_kills = checkNumber(profile[profile.indexOf('Melee Kills') + 1]);
@@ -88,7 +91,8 @@ module.exports = {
         stats_casual.wins = checkNumber(profile[profile.indexOf('Wins') + 1]);
         stats_casual.losses = checkNumber(profile[profile.indexOf('Losses') + 1]);
 
-        stats_casual.time_played = profile[profile.indexOf('Time Played') + 1];
+        time_played = profile[profile.indexOf('Time Played') + 1];
+        stats_casual.time_played = time_played.match(time_played_regex)? time_played: null;
         stats_casual.matches = checkNumber(profile[profile.indexOf('Matches') + 1]);
         stats_casual.kills_match = checkNumber(profile[profile.indexOf('Kills/match') + 1]);
         stats_casual.kills_min = checkNumber(profile[profile.indexOf('Kills/min') + 1]);
@@ -129,7 +133,8 @@ module.exports = {
         stats_rank.wins = checkNumber(profile[profile.indexOf('Wins') + 1]);
         stats_rank.losses = checkNumber(profile[profile.indexOf('Losses') + 1]);
 
-        stats_rank.time_played = profile[profile.indexOf('Time Played') + 1];
+        time_played = profile[profile.indexOf('Time Played') + 1];
+        stats_rank.time_played = time_played.match(time_played_regex)? time_played: null;
         stats_rank.matches = checkNumber(profile[profile.indexOf('Matches') + 1]);
         stats_rank.kills_match = checkNumber(profile[profile.indexOf('Kills/match') + 1]);
         stats_rank.kills_min = checkNumber(profile[profile.indexOf('Kills/min') + 1]);
@@ -256,7 +261,8 @@ module.exports = {
 
         stats_operator.headshots_ = profile[board.indexOf('Headshot %')];
 
-        stats_operator.time_played = profile[board.indexOf('Time Played')];
+        time_played = profile[profile.indexOf('Time Played') + 1];
+        stats_operator.time_played = time_played.match(time_played_regex)? time_played: null;
         stats_operator.dbnos = profile[board.indexOf('DBNOs')];
         stats_operator.xp = profile[board.indexOf('XP')];
         stats_operator.melee_kills = checkNumber(profile[board.indexOf('Melee Kills')]);


### PR DESCRIPTION
Time played for some players doesn't appear at all, leading to this behavior:

time_played: '\#69,087,972'

Fixed this behavior with time_played regular expression validation:

time_played: null